### PR TITLE
Cross build with Scala 2.12.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,8 @@
+import sbt.Keys.crossScalaVersions
+
+lazy val scala212               = "2.12.10"
+lazy val scala213               = "2.13.3"
+lazy val supportedScalaVersions = List(scala212, scala213)
 
 ThisBuild / scalaVersion := "2.13.3"
 ThisBuild / organization := "io.github.kirill5k"
@@ -22,7 +27,8 @@ lazy val noPublish = Seq(
 lazy val root = (project in file("."))
   .settings(noPublish)
   .settings(
-    name := "kafka-connect-http"
+    name := "kafka-connect-http",
+    crossScalaVersions := Nil
   )
   .aggregate(sink)
 
@@ -31,7 +37,8 @@ lazy val commonSettings = Seq(
   startYear := Some(2020),
   licenses += ("Apache-2.0", new URL("https://www.apache.org/licenses/LICENSE-2.0.txt")),
   resolvers += "Apache public" at "https://repository.apache.org/content/groups/public/",
-  scalafmtOnCompile := true
+  scalafmtOnCompile := true,
+  crossScalaVersions := supportedScalaVersions
 )
 
 lazy val sink = (project in file("connectors/sink"))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,19 +9,21 @@ object Dependencies {
     lazy val circe     = "0.13.0"
     lazy val sttp      = "2.2.5"
 
-    lazy val scalatest  = "3.2.0"
-    lazy val mockito    = "1.14.0"
-    lazy val mockserver = "5.11.1"
-
+    lazy val scalatest   = "3.2.0"
+    lazy val mockito     = "1.14.0"
+    lazy val mockserver  = "5.11.1"
+    lazy val scalaCompat = "2.2.0"
   }
 
   object Libraries {
+
+    lazy val scalaCompat       = "org.scala-lang.modules"       %% "scala-collection-compat"          % Versions.scalaCompat
     lazy val connectApi        = "org.apache.kafka"             % "connect-api"                       % Versions.kafka
     lazy val connectAvro       = "io.confluent"                 % "kafka-connect-avro-converter"      % Versions.confluent
     lazy val connectJson       = "org.apache.kafka"             % "connect-json"                      % Versions.kafka
     lazy val sttpCore          = "com.softwaremill.sttp.client" %% "core"                             % Versions.sttp
     lazy val sttpFutureBackend = "com.softwaremill.sttp.client" %% "async-http-client-backend-future" % Versions.sttp
-    lazy val scalajHttp  = "org.scalaj"       %% "scalaj-http"                 % Versions.scalaj
+    lazy val scalajHttp        = "org.scalaj"                   %% "scalaj-http"                      % Versions.scalaj
 
     lazy val circeCore    = "io.circe" %% "circe-core"    % Versions.circe
     lazy val circeParser  = "io.circe" %% "circe-parser"  % Versions.circe
@@ -34,6 +36,7 @@ object Dependencies {
   }
 
   lazy val sink = Seq(
+    Libraries.scalaCompat,
     Libraries.connectApi,
     Libraries.connectAvro,
     Libraries.connectJson,


### PR DESCRIPTION
## Why?
Confluent platform docker images contain Scala 2.12. Cross-build allows to use this project with older confluent platform versions.

## What? 
Added cross-build to Scala 2.12.10